### PR TITLE
fix: guard choices[0] and message=None before content access

### DIFF
--- a/m02_llm_fundamentals/s01_basic_llm_invocation.py
+++ b/m02_llm_fundamentals/s01_basic_llm_invocation.py
@@ -14,4 +14,6 @@ response = client.chat.completions.create(
     stream=False # 非流式输出, 只会等语句全部生成才返回
 )
 
+if not response.choices or response.choices[0].message is None:
+    raise ValueError("LLM returned empty or filtered response")
 print(response.choices[0].message.content)

--- a/m02_llm_fundamentals/s02_conversational_agent.py
+++ b/m02_llm_fundamentals/s02_conversational_agent.py
@@ -14,6 +14,8 @@ def chat_loop(agent_client):
             model="deepseek-chat",
             messages=messages
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         answer = response.choices[0].message.content
         print(f'回答:{answer}')
 

--- a/m02_llm_fundamentals/s03_llm_temperature.py
+++ b/m02_llm_fundamentals/s03_llm_temperature.py
@@ -24,7 +24,11 @@ response_high_temperature = client.chat.completions.create(
 
 
 # 测试1：低温度 (稳定)
+if not response_low_temperature.choices or response_low_temperature.choices[0].message is None:
+    raise ValueError("LLM returned empty or filtered response")
 print(f"温度 0.1: {response_low_temperature.choices[0].message.content}")
 
 # 测试2：高温度 (随机)
+if not response_high_temperature.choices or response_high_temperature.choices[0].message is None:
+    raise ValueError("LLM returned empty or filtered response")
 print(f"温度 1.3: {response_high_temperature.choices[0].message.content}")

--- a/m03_function_calling_tools/s01_custom_function_calling.py
+++ b/m03_function_calling_tools/s01_custom_function_calling.py
@@ -47,6 +47,8 @@ def chat_loop(agent_client, tools):
         tools=tools,  # 调用工具
         tool_choice="auto"  # 模型自主选择是否调用工具
     )
+    if not response.choices or response.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     message = response.choices[0].message
     # 如果有该参数，证明ai调用了工具
     if message.tool_calls:
@@ -74,10 +76,14 @@ def chat_loop(agent_client, tools):
             messages=messages
         )
         print('已调用工具...')
+        if not final_res.choices or final_res.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         print(f'回答:{final_res.choices[0].message.content}')
     else:
         # 模型没有要调用工具, 直接返回
         print('未调用工具...')
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         print(f'回答:{response.choices[0].message.content}')
 
 

--- a/m03_function_calling_tools/s02_api_invocation.py
+++ b/m03_function_calling_tools/s02_api_invocation.py
@@ -41,6 +41,8 @@ def chat_loop(agent_client,tools):
         tools=tools,
         tool_choice="auto"
     )
+    if not response.choices or response.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     message = response.choices[0].message
     if message.tool_calls:
         for tool_call in message.tool_calls:
@@ -65,10 +67,14 @@ def chat_loop(agent_client,tools):
                     messages=messages
                 )
                 print('已调用工具...')
+                if not final_res.choices or final_res.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 print(f'回答:{final_res.choices[0].message.content}')
     else:
         # 模型没有要调用工具，直接返回
         print('未调用工具...')
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         print(f'回答:{response.choices[0].message.content}')
 
 


### PR DESCRIPTION
## Summary

OpenAI-compatible APIs can return **empty `choices`** on error or rate-limiting, causing `IndexError` at `choices[0]`. Gemini additionally returns `choices[0].message = None` on `PROHIBITED_CONTENT` safety filtering (HTTP 200 — no exception raised), causing `AttributeError` at `.content`.

This PR adds:
```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```
before every bare `choices[0].message.content` access (8 sites, 5 files).

## Files changed
- `m02_llm_fundamentals/s01_basic_llm_invocation.py`
- `m02_llm_fundamentals/s02_conversational_agent.py`
- `m02_llm_fundamentals/s03_llm_temperature.py` (two different response vars)
- `m03_function_calling_tools/s01_custom_function_calling.py`
- `m03_function_calling_tools/s02_api_invocation.py`

Static analysis via [pact](https://github.com/qizwiz/pact) found all 8 sites; post-fix scan returns 0 violations.